### PR TITLE
fix: resolve deanmalmgren#342

### DIFF
--- a/textract/parsers/msg_parser.py
+++ b/textract/parsers/msg_parser.py
@@ -8,13 +8,15 @@ from .utils import BaseParser
 def ensure_bytes(string):
     """Normalize string to bytes.
 
-    `ExtractMsg.Message._getStringStream` can return unicode or bytes depending
+    `extract_msg.Message._getStringStream` can return unicode or bytes depending
     on what is originally stored in message file.
 
     This helper functon makes sure, that bytes type is returned.
     """
     if isinstance(string, six.string_types):
         return string.encode('utf-8')
+    if string is None:
+        return b''
     return string
 
 


### PR DESCRIPTION
From: https://github.com/deanmalmgren/textract/pull/422

> Clarification, _getStringStream *should* return `unicode` in Python 2, `str` in Python 3, IF the stream requested exists. If it does not exist, it returns `None`, which cannot be added to bytes. This commit adds a check for None, returning an empty bytes string if matched.

Fixes: https://github.com/deanmalmgren/textract/issues/342